### PR TITLE
#129 Implement a force refresh page

### DIFF
--- a/web-frame/src/app-feature/account-feature/account-feature-routing.module.ts
+++ b/web-frame/src/app-feature/account-feature/account-feature-routing.module.ts
@@ -9,7 +9,7 @@
  */
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { ForceRefreshPageComponent } from '~app-shared/core';
+import { FORCE_REFRESH_PAGE_ROUTE } from '~app-shared/core';
 import { AnonymousGuard, AuthenticatedGuard } from '~app-shared/security';
 import { MinimalShellComponent } from '~app-shell/minimal-shell';
 
@@ -30,10 +30,7 @@ const routes: Routes = [
     pathMatch: 'full',
     redirectTo: 'login',
   },
-  {
-    path: 'force-refresh',
-    component: ForceRefreshPageComponent,
-  },
+  FORCE_REFRESH_PAGE_ROUTE,
   {
     path: '',
     component: MinimalShellComponent,

--- a/web-frame/src/app-feature/account-feature/account-feature-routing.module.ts
+++ b/web-frame/src/app-feature/account-feature/account-feature-routing.module.ts
@@ -9,6 +9,7 @@
  */
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { ForceRefreshPageComponent } from '~app-shared/core';
 import { AnonymousGuard, AuthenticatedGuard } from '~app-shared/security';
 import { MinimalShellComponent } from '~app-shell/minimal-shell';
 
@@ -28,6 +29,10 @@ const routes: Routes = [
     path: '',
     pathMatch: 'full',
     redirectTo: 'login',
+  },
+  {
+    path: 'force-refresh',
+    component: ForceRefreshPageComponent,
   },
   {
     path: '',

--- a/web-frame/src/app-feature/profile-feature/profile-feature.module.ts
+++ b/web-frame/src/app-feature/profile-feature/profile-feature.module.ts
@@ -36,7 +36,6 @@ const FEATURE_COMPONENTS: Type<unknown>[] = [
     SecurityModule,
     ProfileFeatureRoutingModule,
   ],
-  exports: [],
   declarations: [
     FEATURE_COMPONENTS,
   ],

--- a/web-frame/src/app-feature/sandbox-feature/components-sandbox/components-sandbox.module.ts
+++ b/web-frame/src/app-feature/sandbox-feature/components-sandbox/components-sandbox.module.ts
@@ -20,6 +20,5 @@ import { DataTablePageComponent } from './pages/data-table-page/data-table-page.
     DefaultShellModule,
   ],
   declarations: [DataTablePageComponent],
-  exports: [DataTablePageComponent],
 })
 export class ComponentsSandboxModule { }

--- a/web-frame/src/app-feature/sandbox-feature/loading-sandbox/components/slow-loading-sandbox-page/slow-loading.resolver.ts
+++ b/web-frame/src/app-feature/sandbox-feature/loading-sandbox/components/slow-loading-sandbox-page/slow-loading.resolver.ts
@@ -9,11 +9,11 @@ import { Observable, of } from 'rxjs';
 import { delay } from 'rxjs/operators';
 
 @Injectable()
-export class SlowLoadingResolver implements Resolve<boolean> {
-  public resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+export class SlowLoadingResolver implements Resolve<void> {
+  public resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<void> {
     const pageLoadDelay: number = 5000;
 
-    return of(true).pipe(
+    return of(undefined).pipe(
       delay(pageLoadDelay),
     );
   }

--- a/web-frame/src/app-feature/sandbox-feature/loading-sandbox/components/slow-loading-sandbox-page/slow-loading.resolver.ts
+++ b/web-frame/src/app-feature/sandbox-feature/loading-sandbox/components/slow-loading-sandbox-page/slow-loading.resolver.ts
@@ -9,7 +9,7 @@ import { Observable, of } from 'rxjs';
 import { delay } from 'rxjs/operators';
 
 @Injectable()
-export class SlowLoadingResolveGuard implements Resolve<boolean> {
+export class SlowLoadingResolver implements Resolve<boolean> {
   public resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     const pageLoadDelay: number = 5000;
 

--- a/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.module.ts
+++ b/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.module.ts
@@ -9,8 +9,8 @@ import { RouterModule } from '@angular/router';
 import { DefaultShellModule } from '~app-shell/default-shell';
 
 import { SlowLoadingCanActivateGuard } from './components/slow-loading-sandbox-page/slow-loading-can-activate.guard';
-import { SlowLoadingResolver } from './components/slow-loading-sandbox-page/slow-loading.resolver';
 import { SlowLoadingSandboxPageComponent } from './components/slow-loading-sandbox-page/slow-loading-sandbox-page.component';
+import { SlowLoadingResolver } from './components/slow-loading-sandbox-page/slow-loading.resolver';
 import { LOADING_SANDBOX_ROUTES } from './loading-sandbox.routes';
 
 @NgModule({

--- a/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.module.ts
+++ b/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.module.ts
@@ -9,7 +9,7 @@ import { RouterModule } from '@angular/router';
 import { DefaultShellModule } from '~app-shell/default-shell';
 
 import { SlowLoadingCanActivateGuard } from './components/slow-loading-sandbox-page/slow-loading-can-activate.guard';
-import { SlowLoadingResolveGuard } from './components/slow-loading-sandbox-page/slow-loading-resolve.guard';
+import { SlowLoadingResolver } from './components/slow-loading-sandbox-page/slow-loading.resolver';
 import { SlowLoadingSandboxPageComponent } from './components/slow-loading-sandbox-page/slow-loading-sandbox-page.component';
 import { LOADING_SANDBOX_ROUTES } from './loading-sandbox.routes';
 
@@ -24,7 +24,7 @@ import { LOADING_SANDBOX_ROUTES } from './loading-sandbox.routes';
   ],
   providers: [
     SlowLoadingCanActivateGuard,
-    SlowLoadingResolveGuard,
+    SlowLoadingResolver,
   ],
 })
 export class LoadingSandboxModule {

--- a/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.routes.ts
+++ b/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.routes.ts
@@ -25,7 +25,7 @@ export const LOADING_SANDBOX_ROUTES: Routes = [
       {
         path: 'slow-resolve',
         resolve: {
-          boolean: SlowLoadingResolver,
+          slowLoading: SlowLoadingResolver,
         },
         component: SlowLoadingSandboxPageComponent,
       },

--- a/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.routes.ts
+++ b/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.routes.ts
@@ -7,8 +7,8 @@ import { Routes } from '@angular/router';
 import { DefaultShellComponent } from '~app-shell/default-shell';
 
 import { SlowLoadingCanActivateGuard } from './components/slow-loading-sandbox-page/slow-loading-can-activate.guard';
-import { SlowLoadingResolver } from './components/slow-loading-sandbox-page/slow-loading.resolver';
 import { SlowLoadingSandboxPageComponent } from './components/slow-loading-sandbox-page/slow-loading-sandbox-page.component';
+import { SlowLoadingResolver } from './components/slow-loading-sandbox-page/slow-loading.resolver';
 
 export const LOADING_SANDBOX_ROUTES: Routes = [
   {

--- a/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.routes.ts
+++ b/web-frame/src/app-feature/sandbox-feature/loading-sandbox/loading-sandbox.routes.ts
@@ -7,7 +7,7 @@ import { Routes } from '@angular/router';
 import { DefaultShellComponent } from '~app-shell/default-shell';
 
 import { SlowLoadingCanActivateGuard } from './components/slow-loading-sandbox-page/slow-loading-can-activate.guard';
-import { SlowLoadingResolveGuard } from './components/slow-loading-sandbox-page/slow-loading-resolve.guard';
+import { SlowLoadingResolver } from './components/slow-loading-sandbox-page/slow-loading.resolver';
 import { SlowLoadingSandboxPageComponent } from './components/slow-loading-sandbox-page/slow-loading-sandbox-page.component';
 
 export const LOADING_SANDBOX_ROUTES: Routes = [
@@ -25,7 +25,7 @@ export const LOADING_SANDBOX_ROUTES: Routes = [
       {
         path: 'slow-resolve',
         resolve: {
-          boolean: SlowLoadingResolveGuard,
+          boolean: SlowLoadingResolver,
         },
         component: SlowLoadingSandboxPageComponent,
       },

--- a/web-frame/src/app-feature/sandbox-feature/placeholder-sandbox/placeholder-sandbox.module.ts
+++ b/web-frame/src/app-feature/sandbox-feature/placeholder-sandbox/placeholder-sandbox.module.ts
@@ -20,7 +20,6 @@ import { PlaceholderSandboxComponent } from './placeholder-sandbox.component';
     MinimalShellModule,
     PlaceholderSandboxRoutingModule,
   ],
-  exports: [],
   declarations: [PlaceholderSandboxComponent],
   providers: [],
 })

--- a/web-frame/src/app-feature/sandbox-feature/sandbox-feature.component.html
+++ b/web-frame/src/app-feature/sandbox-feature/sandbox-feature.component.html
@@ -10,6 +10,7 @@
   <h2>Patterns</h2>
   <a routerLink="./loading/slow-can-activate">Page with slow CanActivate guard</a>
   <a routerLink="./loading/slow-resolve">Page with slow Resolve guard</a>
+  <a routerLink="/account/force-refresh">Open the force-refresh page</a>
 
   <h2>Shell demo pages</h2>
   <a routerLink="./placeholder/minimal/example-page-(Minimal-Shell)">Minimal Shell</a>

--- a/web-frame/src/app-feature/sandbox-feature/sandbox-feature.component.html
+++ b/web-frame/src/app-feature/sandbox-feature/sandbox-feature.component.html
@@ -10,7 +10,7 @@
   <h2>Patterns</h2>
   <a routerLink="./loading/slow-can-activate">Page with slow CanActivate guard</a>
   <a routerLink="./loading/slow-resolve">Page with slow Resolve guard</a>
-  <a routerLink="/account/force-refresh">Open the force-refresh page</a>
+  <a routerLink="/account/force-refresh" [queryParams]="forceRefreshQueryParams" [skipLocationChange]="true">Open the force-refresh page</a>
 
   <h2>Shell demo pages</h2>
   <a routerLink="./placeholder/minimal/example-page-(Minimal-Shell)">Minimal Shell</a>

--- a/web-frame/src/app-feature/sandbox-feature/sandbox-feature.component.ts
+++ b/web-frame/src/app-feature/sandbox-feature/sandbox-feature.component.ts
@@ -9,6 +9,7 @@
  * to lazy-loaded sub-modules.
  */
 import { ChangeDetectionStrategy, Component, HostBinding, OnInit, ViewEncapsulation } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-sandbox-feature',
@@ -22,9 +23,17 @@ export class SandboxFeatureComponent implements OnInit {
   @HostBinding('class.app-sandbox-feature')
   public componentClass: boolean = true;
 
-  constructor() { }
+  public forceRefreshQueryParams: Record<string, string>;
+
+  constructor(
+    private router: Router,
+  ) {
+  }
 
   public ngOnInit(): void {
+    this.forceRefreshQueryParams = {
+      destination: this.router.url,
+    };
   }
 
   public getPageTitle(): string {

--- a/web-frame/src/app-feature/sandbox-feature/sandbox-feature.module.ts
+++ b/web-frame/src/app-feature/sandbox-feature/sandbox-feature.module.ts
@@ -22,7 +22,6 @@ const FEATURE_COMPONENTS: Type<unknown>[] = [
     SandboxFeatureRoutingModule,
     DefaultShellModule,
   ],
-  exports: [],
   declarations: [
     FEATURE_COMPONENTS,
   ],

--- a/web-frame/src/app-shared/core/components/force-refresh-page/force-refresh-page.component.ts
+++ b/web-frame/src/app-shared/core/components/force-refresh-page/force-refresh-page.component.ts
@@ -36,7 +36,6 @@ export class ForceRefreshPageComponent implements OnDestroy, OnInit {
   }
 
   public ngOnInit(): void {
-    console.log('ForceRefreshPageComponent.ngOnInit()', this.appRefresherList);
     if (this.appRefresherList && this.appRefresherList.length) {
       this.doRefreshSubscription = this.doRefresh().subscribe((): void => {
         this.navigateToDestinationPage();
@@ -55,7 +54,6 @@ export class ForceRefreshPageComponent implements OnDestroy, OnInit {
     const observableList: Observable<void>[] = [];
     sortBy(this.appRefresherList, ['refresherWeight']).forEach((appRefresher: IAppRefresher): void => {
       observableList.push(appRefresher.refresh());
-      console.log('appRefresher', appRefresher);
     });
 
     return concat(...observableList);

--- a/web-frame/src/app-shared/core/components/force-refresh-page/force-refresh-page.component.ts
+++ b/web-frame/src/app-shared/core/components/force-refresh-page/force-refresh-page.component.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2020 THREEANGLE SOFTWARE SOLUTIONS SRL
+ * Available under MIT license webFrame/LICENSE
+ */
+import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit, Optional } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { sortBy } from 'lodash';
+import { concat, Observable, Subscription } from 'rxjs';
+import { APP_REFRESHER, IAppRefresher, IWebFrameContextNavigationService, PAGE_URL } from '~app-shared/core';
+
+@Component({
+  selector: 'app-force-refresh-page',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ForceRefreshPageComponent implements OnDestroy, OnInit {
+  private doRefreshSubscription: Subscription;
+
+  constructor(
+    @Inject(APP_REFRESHER) @Optional()
+    private appRefresherList: IAppRefresher[] | null,
+    @Inject(IWebFrameContextNavigationService)
+    private navigationService: IWebFrameContextNavigationService,
+    private activatedRoute: ActivatedRoute,
+  ) {
+  }
+
+  public ngOnDestroy(): void {
+    if (this.doRefreshSubscription) {
+      this.doRefreshSubscription.unsubscribe();
+    }
+  }
+
+  public ngOnInit(): void {
+    console.log('ForceRefreshPageComponent.ngOnInit()', this.appRefresherList);
+    if (this.appRefresherList && this.appRefresherList.length) {
+      this.doRefreshSubscription = this.doRefresh().subscribe((): void => {
+        this.navigateToDestinationPage();
+      });
+    } else {
+      this.navigateToDestinationPage();
+    }
+  }
+
+  private navigateToDestinationPage(): void {
+    const destinationUrl: string = this.activatedRoute.snapshot.queryParamMap.get('destination') || PAGE_URL.HOME_PAGE;
+    this.navigationService.navigateToUrl(destinationUrl);
+  }
+
+  private doRefresh(): Observable<void> {
+    const observableList: Observable<void>[] = [];
+    sortBy(this.appRefresherList, ['refresherWeight']).forEach((appRefresher: IAppRefresher): void => {
+      observableList.push(appRefresher.refresh());
+      console.log('appRefresher', appRefresher);
+    });
+
+    return concat(...observableList);
+  }
+}

--- a/web-frame/src/app-shared/core/components/force-refresh-page/force-refresh-page.component.ts
+++ b/web-frame/src/app-shared/core/components/force-refresh-page/force-refresh-page.component.ts
@@ -7,7 +7,10 @@ import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit, Optional
 import { ActivatedRoute } from '@angular/router';
 import { sortBy } from 'lodash';
 import { concat, Observable, Subscription } from 'rxjs';
-import { APP_REFRESHER, IAppRefresher, IWebFrameContextNavigationService, PAGE_URL } from '~app-shared/core';
+
+import { APP_REFRESHER, IAppRefresher } from '../../other/app-refresher.token';
+import { PAGE_URL } from '../../other/page-url.enum';
+import { IWebFrameContextNavigationService } from '../../service/web-frame-context/web-frame-context-navigation.service';
 
 @Component({
   selector: 'app-force-refresh-page',

--- a/web-frame/src/app-shared/core/components/force-refresh-page/force-refresh-page.component.ts
+++ b/web-frame/src/app-shared/core/components/force-refresh-page/force-refresh-page.component.ts
@@ -3,12 +3,9 @@
  * Copyright (c) 2020 THREEANGLE SOFTWARE SOLUTIONS SRL
  * Available under MIT license webFrame/LICENSE
  */
-import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit, Optional } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { sortBy } from 'lodash';
-import { concat, Observable, Subscription } from 'rxjs';
 
-import { APP_REFRESHER, IAppRefresher } from '../../other/app-refresher.token';
 import { PAGE_URL } from '../../other/page-url.enum';
 import { IWebFrameContextNavigationService } from '../../service/web-frame-context/web-frame-context-navigation.service';
 
@@ -18,11 +15,8 @@ import { IWebFrameContextNavigationService } from '../../service/web-frame-conte
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ForceRefreshPageComponent implements OnDestroy, OnInit {
-  private doRefreshSubscription: Subscription;
 
   constructor(
-    @Inject(APP_REFRESHER) @Optional()
-    private appRefresherList: IAppRefresher[] | null,
     @Inject(IWebFrameContextNavigationService)
     private navigationService: IWebFrameContextNavigationService,
     private activatedRoute: ActivatedRoute,
@@ -30,19 +24,10 @@ export class ForceRefreshPageComponent implements OnDestroy, OnInit {
   }
 
   public ngOnDestroy(): void {
-    if (this.doRefreshSubscription) {
-      this.doRefreshSubscription.unsubscribe();
-    }
   }
 
   public ngOnInit(): void {
-    if (this.appRefresherList && this.appRefresherList.length) {
-      this.doRefreshSubscription = this.doRefresh().subscribe((): void => {
-        this.navigateToDestinationPage();
-      });
-    } else {
-      this.navigateToDestinationPage();
-    }
+    this.navigateToDestinationPage();
   }
 
   private navigateToDestinationPage(): void {
@@ -50,12 +35,4 @@ export class ForceRefreshPageComponent implements OnDestroy, OnInit {
     this.navigationService.navigateToUrl(destinationUrl);
   }
 
-  private doRefresh(): Observable<void> {
-    const observableList: Observable<void>[] = [];
-    sortBy(this.appRefresherList, ['refresherWeight']).forEach((appRefresher: IAppRefresher): void => {
-      observableList.push(appRefresher.refresh());
-    });
-
-    return concat(...observableList);
-  }
 }

--- a/web-frame/src/app-shared/core/core.module.ts
+++ b/web-frame/src/app-shared/core/core.module.ts
@@ -132,7 +132,7 @@ const SHARED_ROOT_PROVIDERS: Provider[] = [
   },
   {
     provide: APP_REFRESHER,
-    useClass: WebFrameContextStateService,
+    useExisting: IWebFrameContextStateService,
     multi: true,
   },
   {

--- a/web-frame/src/app-shared/core/core.module.ts
+++ b/web-frame/src/app-shared/core/core.module.ts
@@ -13,10 +13,12 @@ import { ModuleWithProviders, NgModule, Provider, Type } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '~app-shared/translate';
 
+import { ForceRefreshPageComponent } from './components/force-refresh-page/force-refresh-page.component';
 import { FormControlErrorsComponent } from './components/form-control-errors/form-control-errors.component';
 import { LanguageSwitcherComponent } from './components/language-switcher/language-switcher.component';
 import { ProgressBarComponent } from './components/progress-bar/progress-bar.component';
 import { APP_INITIALIZER_PROVIDERS } from './initializers/app-initializer.factory';
+import { APP_REFRESHER } from './other/app-refresher.token';
 import {
   AccountService,
   IAccountService,
@@ -64,6 +66,7 @@ import { IWebRequestService } from './service/web-request/web-request.interface'
 import { WebRequestService } from './service/web-request/web-request.service';
 
 const SHARED_COMPONENTS: Type<unknown>[] = [
+  ForceRefreshPageComponent,
   FormControlErrorsComponent,
   LanguageSwitcherComponent,
   ProgressBarComponent,
@@ -124,6 +127,11 @@ const SHARED_ROOT_PROVIDERS: Provider[] = [
   {
     provide: IWebFrameContextStateService,
     useClass: WebFrameContextStateService,
+  },
+  {
+    provide: APP_REFRESHER,
+    useClass: WebFrameContextStateService,
+    multi: true,
   },
   {
     provide: IWebFrameContextUIService,

--- a/web-frame/src/app-shared/core/core.module.ts
+++ b/web-frame/src/app-shared/core/core.module.ts
@@ -19,6 +19,7 @@ import { LanguageSwitcherComponent } from './components/language-switcher/langua
 import { ProgressBarComponent } from './components/progress-bar/progress-bar.component';
 import { APP_INITIALIZER_PROVIDERS } from './initializers/app-initializer.factory';
 import { APP_REFRESHER } from './other/app-refresher.token';
+import { ForceRefreshPageResolver } from './other/force-refresh-page.resolver';
 import {
   AccountService,
   IAccountService,
@@ -79,6 +80,7 @@ const SHARED_PIPES: Type<unknown>[] = [
 ];
 
 const SHARED_ROOT_PROVIDERS: Provider[] = [
+  ForceRefreshPageResolver,
   {
     provide: IAccountService,
     useClass: AccountService,

--- a/web-frame/src/app-shared/core/index.ts
+++ b/web-frame/src/app-shared/core/index.ts
@@ -10,10 +10,15 @@
 
 export { CoreModule } from './core.module';
 
+export { ForceRefreshPageComponent } from './components/force-refresh-page/force-refresh-page.component';
 export { User } from './data/user.do';
 export { Empty } from './data/empty.do';
 export { PagedResult } from './data/paged-result.do';
 export { Dictionary } from './interfaces/dictionary';
+export {
+  IAppRefresher,
+  APP_REFRESHER,
+} from './other/app-refresher.token';
 export { PAGE_URL } from './other/page-url.enum';
 
 export {

--- a/web-frame/src/app-shared/core/index.ts
+++ b/web-frame/src/app-shared/core/index.ts
@@ -10,7 +10,6 @@
 
 export { CoreModule } from './core.module';
 
-export { ForceRefreshPageComponent } from './components/force-refresh-page/force-refresh-page.component';
 export { User } from './data/user.do';
 export { Empty } from './data/empty.do';
 export { PagedResult } from './data/paged-result.do';
@@ -19,6 +18,7 @@ export {
   IAppRefresher,
   APP_REFRESHER,
 } from './other/app-refresher.token';
+export { FORCE_REFRESH_PAGE_ROUTE } from './other/force-refresh-page.route';
 export { PAGE_URL } from './other/page-url.enum';
 
 export {

--- a/web-frame/src/app-shared/core/other/app-refresher.token.ts
+++ b/web-frame/src/app-shared/core/other/app-refresher.token.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright (c) 2020 THREEANGLE SOFTWARE SOLUTIONS SRL
+ * Available under MIT license webFrame/LICENSE
+ */
+import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+
+export interface IAppRefresher {
+  /**
+   * Controls the execution order, the APP_REFRESHER instances with lower weight will be executed first.
+   */
+  refresherWeight: number;
+
+  /**
+   * Method for performing the refresh.
+   */
+  refresh(): Observable<void>;
+}
+
+/**
+ * An injection token that allows you to provide one or more refresher functions.
+ * These function are injected when a module is imported and executed when the
+ * force-refresh page is initialized.
+ *
+ * NOTE: Whenever possible, the force-refresh page should be avoided.
+ */
+export const APP_REFRESHER: InjectionToken<IAppRefresher[]>
+  = new InjectionToken<IAppRefresher[]>('APP_REFRESHER');

--- a/web-frame/src/app-shared/core/other/force-refresh-page.resolver.ts
+++ b/web-frame/src/app-shared/core/other/force-refresh-page.resolver.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright (c) 2020 THREEANGLE SOFTWARE SOLUTIONS SRL
+ * Available under MIT license webFrame/LICENSE
+ */
+import { Inject, Injectable, Optional } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import { sortBy } from 'lodash';
+import { concat, Observable } from 'rxjs';
+
+import { APP_REFRESHER, IAppRefresher } from './app-refresher.token';
+
+@Injectable()
+export class ForceRefreshPageResolver implements Resolve<void> {
+  constructor(
+    @Inject(APP_REFRESHER) @Optional()
+    private appRefresherList: IAppRefresher[] | null,
+  ) {
+  }
+
+  public resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<void> | void {
+    if (this.appRefresherList && this.appRefresherList.length) {
+      return this.doRefresh();
+    }
+
+    return undefined;
+  }
+
+  private doRefresh(): Observable<void> {
+    const observableList: Observable<void>[] = [];
+    sortBy(this.appRefresherList, ['refresherWeight'])
+      .forEach((appRefresher: IAppRefresher): void => {
+        observableList.push(appRefresher.refresh());
+      });
+
+    return concat(...observableList);
+  }
+}

--- a/web-frame/src/app-shared/core/other/force-refresh-page.route.ts
+++ b/web-frame/src/app-shared/core/other/force-refresh-page.route.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright (c) 2020 THREEANGLE SOFTWARE SOLUTIONS SRL
+ * Available under MIT license webFrame/LICENSE
+ */
+import { Route } from '@angular/router';
+
+import { ForceRefreshPageComponent } from '../components/force-refresh-page/force-refresh-page.component';
+
+import { ForceRefreshPageResolver } from './force-refresh-page.resolver';
+
+export const FORCE_REFRESH_PAGE_ROUTE: Route = {
+  path: 'force-refresh',
+  component: ForceRefreshPageComponent,
+  resolve: {
+    refreshFinished: ForceRefreshPageResolver,
+  },
+};

--- a/web-frame/src/app-shared/core/other/force-refresh-page.route.ts
+++ b/web-frame/src/app-shared/core/other/force-refresh-page.route.ts
@@ -13,6 +13,6 @@ export const FORCE_REFRESH_PAGE_ROUTE: Route = {
   path: 'force-refresh',
   component: ForceRefreshPageComponent,
   resolve: {
-    refreshFinished: ForceRefreshPageResolver,
+    forceRefresh: ForceRefreshPageResolver,
   },
 };

--- a/web-frame/src/app-shared/core/service/web-frame-context/web-frame-context-state.service.ts
+++ b/web-frame/src/app-shared/core/service/web-frame-context/web-frame-context-state.service.ts
@@ -9,6 +9,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { User } from '../../data/user.do';
+import { IAppRefresher } from '../../other/app-refresher.token';
 import { ServerApi } from '../api-endpoint-builder/api-endpoint-builder.interface';
 import {
   IWebRequestService,
@@ -27,10 +28,12 @@ export interface IWebFrameContextStateService {
 
 export const IWebFrameContextStateService = new InjectionToken('IWebFrameContextStateService');
 
-// TODO: Move outside
 @Injectable()
-export class WebFrameContextStateService implements IWebFrameContextStateService {
+export class WebFrameContextStateService implements IAppRefresher, IWebFrameContextStateService {
   public currentUser: BehaviorSubject<User | undefined>;
+
+  // The state service refresher needs to be executed first.
+  public refresherWeight: number = -100;
 
   constructor(
     @Inject(IWebRequestService)
@@ -51,11 +54,17 @@ export class WebFrameContextStateService implements IWebFrameContextStateService
     const config: RequestConfiguration = {
       serverApi: ServerApi.AccountMe,
     };
+
     return this.webRequest.get(config).pipe(
       map((user: User): void => {
         this.currentUser.next(user);
+
         return undefined;
       }),
     );
+  }
+
+  public refresh(): Observable<void> {
+    return this.initializeCurrentUser()
   }
 }

--- a/web-frame/src/app-shared/core/service/web-frame-context/web-frame-context-state.service.ts
+++ b/web-frame/src/app-shared/core/service/web-frame-context/web-frame-context-state.service.ts
@@ -23,6 +23,7 @@ export interface IWebFrameContextStateService {
   currentUser: BehaviorSubject<User | undefined>;
 
   isAuthenticated(): boolean;
+
   initialize(): Observable<void>;
 }
 
@@ -50,6 +51,10 @@ export class WebFrameContextStateService implements IAppRefresher, IWebFrameCont
     return this.initializeCurrentUser();
   }
 
+  public refresh(): Observable<void> {
+    return this.initializeCurrentUser();
+  }
+
   private initializeCurrentUser(): Observable<void> {
     const config: RequestConfiguration = {
       serverApi: ServerApi.AccountMe,
@@ -62,9 +67,5 @@ export class WebFrameContextStateService implements IAppRefresher, IWebFrameCont
         return undefined;
       }),
     );
-  }
-
-  public refresh(): Observable<void> {
-    return this.initializeCurrentUser()
   }
 }


### PR DESCRIPTION
Added a new `APP_REFRESHER` InjectionToken, this can be used to provide any number of refreshers. The refreshers are ordered by a given weight, this way we can control in which order they are executed. The refreshers are executed in order, to run some of them in paralel, you can provide one refresher that executes the observables in paralel.

NOTE: because we don't have a dedicated feature module for generic pages, I've added the `force-refresh` page to `account`.

Fixes #129